### PR TITLE
Bug fixes and continuous integration updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,12 @@ install:
 - pip install https://github.com/udst/urbansim/archive/master.zip
 - pip install osmnet pandana
 - pip install .
-- cd .. && git clone git@github.com:urbansim/urbansim_parcels.git
-- pip install ./urbansim_parcels
+#- cd .. && git clone git@github.com:urbansim/urbansim_parcels.git
+#- pip install ./urbansim_parcels
 - cd "$TRAVIS_BUILD_DIR"
 
 script:
 - pycodestyle developer
 - py.test
-- cd ../urbansim_parcels/sf_example && python simulate.py
-- cd ../sd_example && python simulate.py
+#- cd ../urbansim_parcels/sf_example && python simulate.py
+#- cd ../sd_example && python simulate.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UrbanSim Developer Model
 
-[![Build Status](https://travis-ci.com/urbansim/developer.svg?token=GSDNqBio5uUExRqdD5zJ&branch=master)](https://travis-ci.com/urbansim/developer)
+[![Build Status](https://travis-ci.org/udst/developer.svg?token=GSDNqBio5uUExRqdD5zJ&branch=master)](https://travis-ci.org/udst/developer)
 
 This package is a new-and-improved version of the developer model
 included in UrbanSim. Documentation available [here](https://urbansim.github.io/developer/).

--- a/developer/develop.py
+++ b/developer/develop.py
@@ -220,7 +220,7 @@ class Developer(object):
         df : DataFrame
         """
 
-		if self.forms is None or isinstance(self.forms, list):
+        if self.forms is None or isinstance(self.forms, list):
             df = self.keep_form_with_max_profit(self.forms)
         else:
             df = self.feasibility[self.forms]

--- a/developer/develop.py
+++ b/developer/develop.py
@@ -220,9 +220,7 @@ class Developer(object):
         df : DataFrame
         """
 
-        if self.forms is None:
-            df = self.feasibility
-        elif isinstance(self.forms, list):
+		if self.forms is None or isinstance(self.forms, list):
             df = self.keep_form_with_max_profit(self.forms)
         else:
             df = self.feasibility[self.forms]
@@ -261,13 +259,15 @@ class Developer(object):
 
         Parameters
         ----------
-        forms: list of strings
-            List of forms which compete which other.  Can leave some out.
+        forms : list of strings
+            List of forms to evaluate. If empty or None, all forms are 
+            evaluated.
 
         Returns
         -------
-        Nothing.  Goes from a multi-index to a single index with only the
-        most profitable form.
+        DataFrame consisting of a subset of self.feasibility, where only
+        the most profitable form for each parcel is included.
+
         """
         f = self.feasibility
 

--- a/developer/develop.py
+++ b/developer/develop.py
@@ -260,7 +260,7 @@ class Developer(object):
         Parameters
         ----------
         forms : list of strings
-            List of forms to evaluate. If empty or None, all forms are 
+            List of forms to evaluate. If empty or None, all forms are
             evaluated.
 
         Returns

--- a/developer/sqftproforma.py
+++ b/developer/sqftproforma.py
@@ -705,7 +705,7 @@ class SqFtProForma(object):
         mask = ~np.isnan(fars)  # mask out existing nans for safer comparison
         mask *= np.nan_to_num(fars) > df.min_max_fars.values + .01
         fars[mask] = np.nan
-        
+
         heights = np.repeat(heights, len(df.index), axis=1)
         mask = ~np.isnan(heights)
         mask *= np.nan_to_num(heights) > df.max_height.values + .01
@@ -1198,7 +1198,7 @@ class SqFtProFormaReference(object):
                           - parking_stalls
                           * self.parking_sqft_d[parking_config]))
             # not all fars support surface parking
-            mask = ~np.isnan(stories)  # mask out existing nans for safer comparison
+            mask = ~np.isnan(stories)  # mask out existing nans
             mask[mask] *= stories[mask] < 0.0
             stories[mask] = np.nan
             # I think we can assume that stories over 3

--- a/developer/sqftproforma.py
+++ b/developer/sqftproforma.py
@@ -702,9 +702,14 @@ class SqFtProForma(object):
         # turn fars and heights into nans which are not allowed by zoning
         # (so we can fillna with one of the other zoning constraints)
         fars = np.repeat(cost_sqft_index_col, len(df.index), axis=1)
-        fars[fars > df.min_max_fars.values + .01] = np.nan
+        mask = ~np.isnan(fars)  # mask out existing nans for safer comparison
+        mask *= np.nan_to_num(fars) > df.min_max_fars.values + .01
+        fars[mask] = np.nan
+        
         heights = np.repeat(heights, len(df.index), axis=1)
-        fars[heights > df.max_height.values + .01] = np.nan
+        mask = ~np.isnan(heights)
+        mask *= np.nan_to_num(heights) > df.max_height.values + .01
+        fars[mask] = np.nan
 
         # PROFIT CALCULATION
         # parcel sizes * possible fars
@@ -1193,10 +1198,14 @@ class SqFtProFormaReference(object):
                           - parking_stalls
                           * self.parking_sqft_d[parking_config]))
             # not all fars support surface parking
-            stories[stories < 0.0] = np.nan
+            mask = ~np.isnan(stories)  # mask out existing nans for safer comparison
+            mask[mask] *= stories[mask] < 0.0
+            stories[mask] = np.nan
             # I think we can assume that stories over 3
             # do not work with surface parking
-            stories[stories > 5.0] = np.nan
+            mask = ~np.isnan(stories)
+            mask[mask] *= stories[mask] > 5.0
+            stories[mask] = np.nan
 
         stories /= self.parcel_coverage
 


### PR DESCRIPTION
EDIT: This PR now includes a number of small changes and bug fixes.

1. Fixes a bug in computing max-profit over all forms. If the argument to "forms" is None, max-profit should be computed over all forms present in the feasibility table. This was raised by @hanase in issue #59, and originally in https://github.com/UDST/urbansim/pull/194.

2. Migrates the Travis hooks from urbansim/developer to udst/developer, to restore continuous integration of the repository.

3. Removes urbansim_parcels dependencies from the Travis script, because these aren't working following the move to UDST. See issue #63.

4. Fixes a problem in sqftproforma.py where arrays possibly containing nans were being compared to numeric values. This evaluated correctly, but caused numpy to raise a warning.