### PR TITLE
Keeping less profitable proposals

### DIFF
--- a/developer/develop.py
+++ b/developer/develop.py
@@ -429,7 +429,7 @@ class Developer(object):
             Index of buildings selected for development
 
         """
-        insufficient_units =  df.net_units.sum() < self.target_units
+        insufficient_units = df.net_units.sum() < self.target_units
         if custom_selection_func is not None:
             build_idx = custom_selection_func(self, df, p)
         elif insufficient_units & (not self.keep_suboptimal):

--- a/developer/proposal_select.py
+++ b/developer/proposal_select.py
@@ -1,0 +1,83 @@
+import numpy as np
+import pandas as pd
+
+
+def weighted_random_choice(df, p, target_units):
+    """
+    Proposal selection using weighted random choice.
+
+    Parameters
+    ----------
+    df : DataFrame
+        Proposals to select from
+    p : Series
+        Weights for each proposal
+    target_units: int
+        Number of units to build
+
+    Returns
+    -------
+    build_idx : ndarray
+        Index of buildings selected for development
+
+    """
+    # We don't know how many developments we will need, as they
+    # differ in net_units. If all developments have net_units of 1
+    # than we need target_units of them. So we choose the smaller
+    # of available developments and target_units.
+    num_to_sample = int(min(len(df.index), target_units))
+    choices = np.random.choice(df.index.values,
+                               size=num_to_sample,
+                               replace=False, p=p)
+    tot_units = df.net_units.loc[choices].values.cumsum()
+    ind = int(np.searchsorted(tot_units, target_units,
+                              side="left")) + 1
+    return choices[:ind]
+
+
+def weighted_random_choice_multiparcel(df, p, target_units):
+    """
+    Proposal selection using weighted random choice in the context of multiple
+    proposals per parcel.
+
+    Parameters
+    ----------
+    df : DataFrame
+        Proposals to select from
+    p : Series
+        Weights for each proposal
+    target_units: int
+        Number of units to build
+
+    Returns
+    -------
+    build_idx : ndarray
+        Index of buildings selected for development
+
+    """
+    choice_idx = weighted_random_choice(df, p, target_units)
+    choices = df.loc[choice_idx]
+    while True:
+        # If multiple proposals sampled for a given parcel, keep only one
+        choice_counts = choices.parcel_id.value_counts()
+        chosen_multiple = choice_counts[choice_counts > 1].index.values
+        single_choices = choices[~choices.parcel_id.isin(chosen_multiple)]
+        duplicate_choices = choices[choices.parcel_id.isin(chosen_multiple)]
+        keep_choice = duplicate_choices.parcel_id.drop_duplicates(keep='first')
+        dup_choices_to_keep = duplicate_choices.loc[keep_choice.index]
+        choices = pd.concat([single_choices, dup_choices_to_keep])
+
+        if choices.net_units.sum() >= target_units:
+            break
+
+        df = df[~df.parcel_id.isin(choices.parcel_id)]
+        if len(df) == 0:
+            break
+
+        p = p.reindex(df.index)
+        p = p / p.sum()
+        new_target = target_units - choices.net_units.sum()
+        next_choice_idx = weighted_random_choice(df, p, new_target)
+        next_choices = df.loc[next_choice_idx]
+        choices = pd.concat([choices, next_choices])
+    return choices.index.values

--- a/developer/tests/test_sqftproforma.py
+++ b/developer/tests/test_sqftproforma.py
@@ -115,6 +115,18 @@ def test_sqftproforma_defaults(simple_dev_inputs):
             assert len(out) == 0
 
 
+def test_sqftproforma_keep_n_best(simple_dev_inputs):
+    pf = sqpf.SqFtProForma.from_defaults()
+
+    number_of_parcels = len(simple_dev_inputs)
+
+    for number_to_keep in range(1, 5):
+        pf.proposals_to_keep = number_to_keep
+        out = pf.lookup('residential', simple_dev_inputs)
+        expected_total_proposals = number_to_keep * number_of_parcels
+        assert len(out) == expected_total_proposals
+
+
 def test_sqftproforma_max_dua(simple_dev_inputs_low_cost, max_dua_dev_inputs):
     pf = sqpf.SqFtProForma.from_defaults()
 


### PR DESCRIPTION
This PR introduces changes to optionally retain less profitable proforma proposals and to support proposal selection when there can be multiple proposals per parcel. 

- Adds an optional `proposals_to_keep` parameter to SqftProForma that allows user to specify the top N proposals of a given form to keep for each parcel.   Defaults to 1 (keep just the most profitable proposal for the form/parcel).  If a value N which is greater than 1 is supplied, then N - 1 sub-optimal proposals are retained in addition to the optimal one.

- Adds an optional `keep_suboptimal` parameter to Developer that avoids dropping less profitable forms for a given parcel and allows Developer to work with a feasibility table in "long-form" (each row is a distinct proposal, with form column indicating the form of the proposal) instead of a feasibility table in "wide-form" (each row represents a parcel and proposals/forms are represented by additional columns).     The long-form feasibility table can more easily represent the situation where multiple proposals for a given form and parcel are present.  Adjustments to the Developer data preparation steps are made to support the feasibility table in this format.   A simple method for selecting proposals when there are many proposals per form is introduced, but users can supply their own proposal selection function via the custom_selection_func callback.  