### PR TITLE
Print warning about insufficient units only if target_units is a number

### DIFF
--- a/developer/develop.py
+++ b/developer/develop.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 import developer.utils as utils
 from developer import proposal_select
+from numbers import Number
 
 logger = logging.getLogger(__name__)
 
@@ -427,7 +428,7 @@ class Developer(object):
 
         """
         insufficient_units = df.net_units.sum() < self.target_units
-        if insufficient_units:
+        if insufficient_units and isinstance(self.target_units, Number):
             print("WARNING THERE ARE NOT ENOUGH PROFITABLE UNITS TO",
                   "MATCH DEMAND")
 


### PR DESCRIPTION
In our case, self.target_units is a dictionary that contains the required number of units for each building type. The selection itself is handled by our own custom_selection_func. Because the self.target_units is not a number, the warning about insufficient units is always printed, regardless of the actual numbers.

Here I added a condition that the warning should be printed only if self.target_units is a number. Other possibility is to print the warning only if custom_selection_func is not set.
