### PR TITLE
formats _select_buildings() to allow vacancies by btype

### DIFF
--- a/developer/develop.py
+++ b/developer/develop.py
@@ -427,11 +427,17 @@ class Developer(object):
             Index of buildings selected for development
 
         """
+        warning = "WARNING THERE ARE NOT ENOUGH PROFITABLE UNITS TO " \
+                  "MATCH DEMAND"
         if isinstance(self.target_units, Number):
             insufficient_units = df.net_units.sum() < self.target_units
             if insufficient_units:
-                print("WARNING THERE ARE NOT ENOUGH PROFITABLE UNITS TO",
-                      "MATCH DEMAND")
+                print(warning)
+        elif isinstance(self.target_units, pd.DataFrame):
+            insufficient_units = \
+                df.net_units.sum() < self.target_units.target_units.sum()
+            if insufficient_units:
+                print(warning)
 
         if custom_selection_func is not None:
             build_idx = custom_selection_func(self, df, p, self.target_units)

--- a/developer/develop.py
+++ b/developer/develop.py
@@ -431,7 +431,7 @@ class Developer(object):
             insufficient_units = df.net_units.sum() < self.target_units
             if insufficient_units:
                 print("WARNING THERE ARE NOT ENOUGH PROFITABLE UNITS TO",
-                    "MATCH DEMAND")
+                      "MATCH DEMAND")
 
         if custom_selection_func is not None:
             build_idx = custom_selection_func(self, df, p, self.target_units)

--- a/developer/develop.py
+++ b/developer/develop.py
@@ -427,10 +427,11 @@ class Developer(object):
             Index of buildings selected for development
 
         """
-        insufficient_units = df.net_units.sum() < self.target_units
-        if insufficient_units and isinstance(self.target_units, Number):
-            print("WARNING THERE ARE NOT ENOUGH PROFITABLE UNITS TO",
-                  "MATCH DEMAND")
+        if isinstance(self.target_units, Number):
+            insufficient_units = df.net_units.sum() < self.target_units
+            if insufficient_units:
+                print("WARNING THERE ARE NOT ENOUGH PROFITABLE UNITS TO",
+                    "MATCH DEMAND")
 
         if custom_selection_func is not None:
             build_idx = custom_selection_func(self, df, p, self.target_units)


### PR DESCRIPTION
Hi @janowicz !

To tackle the need for including building-type-specific vacancy rates (https://github.com/urbansim/consulting-planning/issues/159), I had to make a minor change to the `_select_buildings( )` function in the develop module. 

Thanks!

Jessica