### PR TITLE
use self.target_units for custom functions

### DIFF
--- a/developer/develop.py
+++ b/developer/develop.py
@@ -446,7 +446,7 @@ class Developer(object):
                 print(warning)
 
         if custom_selection_func is not None:
-            build_idx = custom_selection_func(self, df, p, target_units)
+            build_idx = custom_selection_func(self, df, p, self.target_units)
 
         elif target_units <= 0:
             build_idx = []


### PR DESCRIPTION
The `_select_buildings` is a function inside the Developer object. The function selects buildings using the `self.target_units`, a developer property, which can be passed as a Float or as a pd.DataFrame with the column `target_units`. With `self.target_units`, a float variable called `target_units` is created being the `self.target_units` itself, it this is a Float, or a sum of the target_units column if `self.target_units` is a DataFrame. Then, the selection of buildings can be done through three methods: a custom selection passed by the user called `custom_selection_func`, the `weighted_random_choice_multiparcel` method from proposal_select.py or the `weighted_random_choice` method also from proposal_select.py. The three functions uses the `target_units` as inputs. The two latter, defined in proposal_select.py needs a Float type as the `target_units` input, so the variable `target_units` that was created is passed into these. But, as the  `custom_selection_func` is a function that is defined and passed by the user, we assume that it will designed to take as input the original `target_units` that is passed to create the developer object. Therefore, the parameter to pass into the  `custom_selection_func` should be `self.target_units` instead of `target_units`, since in the case `self.target_units` is a pd.DataFrame, the `custom_selection_func` will be expecting that type, instead of a Float which is the local variable `target_units`.